### PR TITLE
feat: show in tooltip

### DIFF
--- a/common/src/main/java/cc/woverflow/pronounmc/config/PronounConfig.java
+++ b/common/src/main/java/cc/woverflow/pronounmc/config/PronounConfig.java
@@ -11,4 +11,7 @@ public class PronounConfig implements ConfigData {
 
     @ConfigEntry.Category("Visibility")
     public boolean showOnNametag = true;
+
+    @ConfigEntry.Category("Visibility")
+    public boolean showInTooltip = true;
 }

--- a/common/src/main/java/cc/woverflow/pronounmc/mixins/EntityContentAccessor.java
+++ b/common/src/main/java/cc/woverflow/pronounmc/mixins/EntityContentAccessor.java
@@ -1,0 +1,13 @@
+package cc.woverflow.pronounmc.mixins;
+
+import net.minecraft.text.HoverEvent;
+import net.minecraft.text.Text;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Mutable;
+import org.spongepowered.asm.mixin.gen.Accessor;
+
+@Mixin(HoverEvent.EntityContent.class)
+public interface EntityContentAccessor {
+    @Accessor("name") @Mutable
+    public void setName(Text name);
+}

--- a/common/src/main/java/cc/woverflow/pronounmc/mixins/EntityContentMixin.java
+++ b/common/src/main/java/cc/woverflow/pronounmc/mixins/EntityContentMixin.java
@@ -1,0 +1,32 @@
+package cc.woverflow.pronounmc.mixins;
+
+import cc.woverflow.pronounmc.PronounMC;
+import cc.woverflow.pronounmc.utils.Pronouns;
+import net.minecraft.entity.EntityType;
+import net.minecraft.text.HoverEvent.EntityContent;
+import net.minecraft.text.LiteralText;
+import net.minecraft.text.Text;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+
+import java.util.List;
+
+@Mixin(EntityContent.class)
+public class EntityContentMixin {
+    @Inject(method = "asTooltip", at = @At("HEAD"))
+    private void modifyTooltip(CallbackInfoReturnable<List<Text>> cir) {
+        if (!((EntityContent)(Object)this).entityType.equals(EntityType.PLAYER)) {
+            return;
+        }
+        if (PronounMC.getConfig().showInTooltip) {
+            Pronouns pronouns = PronounMC.getPronounManager().getOrFindPronouns(((EntityContent)(Object)this).uuid);
+            if (pronouns == null || pronouns == Pronouns.UNSPECIFIED) {
+                return;
+            }
+
+            ((EntityContentAccessor) ((EntityContent)(Object)this)).setName(new LiteralText("").append(((EntityContent)(Object)this).name).append(" (").append(pronouns.getText()).append(")"));
+        }
+    }
+}

--- a/common/src/main/resources/assets/pronounmc/lang/en_us.json
+++ b/common/src/main/resources/assets/pronounmc/lang/en_us.json
@@ -22,5 +22,6 @@
 
   "text.autoconfig.pronounmc.title": "PronounMC Config",
   "text.autoconfig.pronounmc.option.showInChat": "Show In Chat",
-  "text.autoconfig.pronounmc.option.showOnNametag": "Show On Nametag"
+  "text.autoconfig.pronounmc.option.showOnNametag": "Show On Nametag",
+  "text.autoconfig.pronounmc.option.showInTooltip": "Show In Tooltip"
 }

--- a/common/src/main/resources/pronounmc-common.mixins.json
+++ b/common/src/main/resources/pronounmc-common.mixins.json
@@ -8,6 +8,8 @@
   "client": [
     "ClientPlayNetworkHandlerMixin",
     "InGameHudMixin",
-    "EntityRendererMixin"
+    "EntityRendererMixin",
+    "EntityContentMixin",
+    "EntityContentAccessor"
   ]
 }


### PR DESCRIPTION
## Description
Adds the `Show In Tooltip` config option which injects a player's pronouns into the player's entity selector tooltip, e.g. when you hover over the player's name in chat (assuming a vanilla-ish server) or when the player is mentioned in `/tellraw`:
![image](https://user-images.githubusercontent.com/22878174/166088843-70477f6e-b863-4e13-a1e8-b0947f3adb02.png)